### PR TITLE
Bump Node.js version and GitHub actions

### DIFF
--- a/.github/workflows/reusable-base.yml
+++ b/.github/workflows/reusable-base.yml
@@ -45,7 +45,7 @@ jobs:
       - id: split-os
         run: echo "splitted=$(echo '${{ inputs.os || 'ubuntu-latest' }}' | jq -R -c 'split(",")')" >> $GITHUB_OUTPUT
       - id: split-node-versions
-        run: echo "splitted=$(echo '${{ inputs.node-versions || '18' }}' | jq -R -c 'split(",")')" >> $GITHUB_OUTPUT
+        run: echo "splitted=$(echo '${{ inputs.node-versions || '20' }}' | jq -R -c 'split(",")')" >> $GITHUB_OUTPUT
 
   test:
     name: Test
@@ -57,7 +57,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node_version: ${{ fromJson(needs.resolve_inputs.outputs.nodeVersions || '["18"]') }}
+        node_version: ${{ fromJson(needs.resolve_inputs.outputs.nodeVersions || '["20"]') }}
         os: ${{ fromJson(needs.resolve_inputs.outputs.os || '["ubuntu-latest"]') }}
 
     steps:

--- a/.github/workflows/reusable-base.yml
+++ b/.github/workflows/reusable-base.yml
@@ -62,13 +62,13 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         submodules: ${{ inputs.submodules }}
         
 
     - name: Use Node.js ${{ matrix.node_version }}
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node_version }}
 

--- a/.github/workflows/reusable-sync.yml
+++ b/.github/workflows/reusable-sync.yml
@@ -97,14 +97,14 @@ jobs:
     steps:
       # Base setup
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # As we want to check if the remote branch already exists and is up to date
           token: ${{ secrets.GITHUB_TOKEN_OVERRIDE || secrets.GITHUB_TOKEN }}
 
       - name: Set up Node.js
         if: inputs.npm-pre-sync-script || inputs.npm-post-sync-script
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ inputs.node-version }}
 

--- a/.github/workflows/type-check.yml
+++ b/.github/workflows/type-check.yml
@@ -34,7 +34,7 @@ on:
         type: string
       submodules:
         default: false
-        description: 'From actions/checkout@v3'
+        description: 'From actions/checkout@v4'
         required: false
         type: string
 
@@ -73,9 +73,9 @@ jobs:
         ts_lib: ${{ fromJson(needs.resolve_inputs.outputs.tsLibs) }}
         ts_project: ${{ fromJson(needs.resolve_inputs.outputs.tsProjects) }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node_version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           submodules: ${{ inputs.submodules }}
           node-version: ${{ matrix.node_version }}


### PR DESCRIPTION
This PR

-   bumps the Node.js version to install by default from `v18` to current LTS, `v20`
-   bumps the versions of the used GitHub actions to their latest major releases