### PR TITLE
Refactor so test job can be cancelled

### DIFF
--- a/.github/workflows/reusable-base.yml
+++ b/.github/workflows/reusable-base.yml
@@ -37,7 +37,6 @@ jobs:
   resolve_inputs:
     name: Resolving inputs
     runs-on: ubuntu-latest
-    if: ${{ inputs.os || inputs.node-versions}}
     outputs:
       os: ${{ steps.split-os.outputs.splitted }}
       nodeVersions: ${{ steps.split-node-versions.outputs.splitted }}
@@ -52,7 +51,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     needs:
       - resolve_inputs
-    if: ${{ always() }}
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
The `reusable-base` workflow currently has a `if: ${{ always() }}` condition on the test job, which is unfortunate as it means that it will never be cancelled. This should be resolved via this PR.