### PR TITLE
fix: harden GitHub Actions workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,5 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
## Summary
- Add Dependabot cooldown configuration (`default-days: 7`) to the `github-actions` package ecosystem entry, preventing immediate adoption of newly released action versions that may contain undiscovered vulnerabilities or malicious code