### PR TITLE
Fix zizmor workflow

### DIFF
--- a/.github/workflows/audit-gha-workflows.yml
+++ b/.github/workflows/audit-gha-workflows.yml
@@ -18,4 +18,7 @@ jobs:
       - name: Install zizmor
         run: pip install zizmor==1.23.1
       - name: Run zizmor
-        run: zizmor --min-severity medium --min-confidence medium .github/workflows
+        run: |
+          if [ -d .github ]; then
+            zizmor --min-severity medium .github
+          fi


### PR DESCRIPTION
* Run on the whole .github directory, not just .github/workflows
* Only run if .github directory exists