### PR TITLE
Fix credentials for zizmor

### DIFF
--- a/.github/workflows/audit-gha-workflows.yml
+++ b/.github/workflows/audit-gha-workflows.yml
@@ -20,5 +20,5 @@ jobs:
       - name: Run zizmor
         run: |
           if [ -d .github ]; then
-            zizmor --min-severity medium .github
+            zizmor .github --gh-token "${GITHUB_TOKEN}" --min-severity medium
           fi


### PR DESCRIPTION
Zizmor needs to be explicitly passed a github token in order to analyze actions that are called. This analysis suppresses a lot of findings that are not contextually relevant, so this reduces the alert rate significantly.