### PR TITLE
fix: add workflow_dispatch trigger to audit workflow

### DIFF
--- a/.github/workflows/audit-gha-workflows.yml
+++ b/.github/workflows/audit-gha-workflows.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
   push:
     branches: [master, main]
+  workflow_dispatch:
 permissions:
   contents: read
 jobs:


### PR DESCRIPTION
## Summary

- Adds `workflow_dispatch` trigger to `audit-gha-workflows.yml`
- This is required because pushes/PR events made with `GITHUB_TOKEN` don't trigger other workflows, but `workflow_dispatch` is exempt from this restriction
- Allows automated workflows (generate-sdk, weekly-update, etc.) across all Socket repos to trigger the audit check via `gh workflow run`

## Context

Automated PRs created by bot workflows (e.g., OpenAPI sync, weekly dependency updates) have their required "Audit GHA Workflows" check stuck at "Waiting for workflow to run" because the `GITHUB_TOKEN` event suppression prevents the enterprise required workflow from firing.