### PR TITLE
fix: use zizmor-action with digest-pinned Docker images

### DIFF
--- a/.github/workflows/audit-gha-workflows.yml
+++ b/.github/workflows/audit-gha-workflows.yml
@@ -15,12 +15,8 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - name: Install zizmor
-        run: pip install zizmor==1.23.1
       - name: Run zizmor
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          if [ -d .github ]; then
-            zizmor .github --gh-token "${GITHUB_TOKEN}" --min-severity medium
-          fi
+        uses: zizmorcore/zizmor-action@71321a20a9ded102f6e9ce5718a2fcec2c4f70d8 # v0.5.2
+        with:
+          advanced-security: false
+          min-severity: medium


### PR DESCRIPTION
## Summary

- Replaces `pip install zizmor==1.23.1` with the official `zizmorcore/zizmor-action@v0.5.2` (pinned by SHA)
- Uses digest-pinned Docker images for supply chain integrity
- Disables SARIF upload (`advanced-security: false`) since this workflow lacks `security-events: write` permission
- Verified: `zizmor .github --min-severity medium` passes clean

## Test plan

- [ ] Verify zizmor audit still runs on PRs